### PR TITLE
css fixes

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -12,7 +12,7 @@ h1 {
   margin-top: 0;
   margin-bottom: 20px;
   color: #FCFDFB;
-  font-size: 4em;
+  font-size: 3em;
   text-shadow: 3px 3px #000; }
 
 h3 {

--- a/css/main.css
+++ b/css/main.css
@@ -12,7 +12,7 @@ h1 {
   margin-top: 0;
   margin-bottom: 20px;
   color: #FCFDFB;
-  font-size: 3em;
+  font-size: 4em;
   text-shadow: 3px 3px #000; }
 
 h3 {
@@ -34,7 +34,8 @@ h3 {
 
 .moviePoster {
   height: 265px;
-  max-width: 195px; }
+  max-width: 195px;
+  min-width: 195px; }
 
 .rating {
   font-size: .5em; }

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1,5 +1,5 @@
 body {
-	background:  url(../images/mysteryScienceBg.jpg) no-repeat center center fixed; 
+	background:  url(../images/mysteryScienceBg.jpg) no-repeat center center fixed;
 	background-size: cover;
 	font-family: 'Acme', sans-serif;
 	text-shadow: 1px 1px #fff;
@@ -43,6 +43,7 @@ h3 {
 .moviePoster {
 	height: 265px;
 	max-width: 195px;
+	min-width: 195px;
 }
 
 .rating {
@@ -50,7 +51,6 @@ h3 {
 }
 
 .movieCard {
-	
 	background: #fff;
 	text-align: center;
 	margin: 2% 3.5%;

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -14,7 +14,7 @@ h1 {
 	margin-top: 0;
 	margin-bottom: 20px;
 	color: #FCFDFB;
-	font-size: 4em;
+	font-size: 3em;
 	text-shadow: 3px 3px #000;
 }
 


### PR DESCRIPTION
-set min width for movie images. without this, buttons wrap to the right of thin images and cause columns to wrap incorrectly in the search view.
-set smaller h1 in sass. only did that in css last time